### PR TITLE
Fixed Tuple bug for downloading images for gif when adding a new shoe

### DIFF
--- a/sneaker-server/api/routes/user.py
+++ b/sneaker-server/api/routes/user.py
@@ -39,7 +39,7 @@ async def add_to_portfolio(data: PortfolioData):
             (data.userId, shoe_uuid),
         )
         conn.commit()
-        gif_process = Process(target=get_visual_item, args=(shoe_image_url, shoe_uuid))
+        gif_process = Process(target=get_visual_item, args=((shoe_uuid, shoe_image_url),))
         gif_process.start()
     return {"status": "success", "message": "Shoe added to portfolio successfully!"}
 


### PR DESCRIPTION
The argument for `get_visual_item` in `img_utils.py` is a tuple. The process in `add_to_portfolio`, which is executed when a shoe is added, called `get_visual_item` not with one tuple,  but with two parameters. By changing the two parameters to a tuple, this fixes the bug and the downloading process of the images can be initiated when adding a new shoe.